### PR TITLE
Merge Develop as v2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For example, to set the swap size to 12GB , run the following command:
 You can also specify the swapsize by mega byte format. For example: `-s 512M`.
 
 > [!NOTE]
-> If the avairable disk space - specified swap size < 1GB, 
+> If the `avairable disk space after changing swap size` < 1GB, 
 > Fuyujitaku terminates immediately. 
 
 Also, you can specify a parameter to specify the time delay from the entering sleep to the entering hibernaiton. This parameter is set by `-d` optoin. 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following table shows the test environment and results for version 1.x.x of 
 - (#3) The mouse cursor is rendered incorrectly after resuming. The workaround is to reboot the system.
 - (#4) Intel Core i5-8365U, 8GB RAM, 256GB SSD.
 
-### Version 2.0
+### Version 2.0.x
 The following table shows the test environment and results for version 1.x.x of this script.
 | OS                | Platform                       | Note       |
 | ----------------- | ------------------------------ | ---------- |
@@ -55,7 +55,7 @@ The following table shows the test environment and results for version 1.x.x of 
 `
 5. Then reboot your system.
 
-By default the swap size will be set to 2 times the RAM size. Also, the delay from entering sleep to entering hibernation is set to 900 seconds (15 minutes).
+By default the swap size will be set to 2 times the RAM size. Also, the delay from entering sleep to entering hibernation is set to 1440 minutes (24 hours).
 
 If you want to set a different swap size, you can specify it by `-s` option. 
 For example, to set the swap size to 12GB , run the following command:
@@ -95,6 +95,14 @@ To revert the changes, run the following command:
 
 Note that the revert.sh script works only if the fuyujitaku.sh script was run without any errors. 
 
+## How to test
+To run the auto tests, you need to install [shellspec](https://github.com/shellspec/shellspec).
+
+Then, run the following command in the root directory of this project:
+
+```bash
+shellspec
+```
 ## Troubleshooting
 If you encounter any issues while using this script, please check the following:
 - Ensure that you have a swap file and not a swap partition. This script does not support systems with swap partitions.

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -72,7 +72,7 @@ print_usage() {
     echo "                       If not specified, it will be set to 2 times the RAM size."
     echo "            -d DELAY : Hibernate delay time. DELAY isNNNs, NNNm format."    
     echo "                       Where s is seconds and m is minutes."
-    echo "                       If not specified, it will be set to 15m."
+    echo "                       If not specified, it will be set to 1440m(24h)."
 
     return 0
 }
@@ -115,10 +115,10 @@ set_default_target_swap_size() {
 }
 
 # Set default value to the HIBERNATE_DELAY_SEC variable.
-# The default value is 15 minutes.
+# The default value is 1440 minutes.
 # The value must have 'm' suffix.
 set_default_hibernate_delay_sec() {
-    HIBERNATE_DELAY_SEC="15m"
+    HIBERNATE_DELAY_SEC="1440m"
 
     return 0
 }

--- a/spec/set_default_hibernate_delay_sec_spec.sh
+++ b/spec/set_default_hibernate_delay_sec_spec.sh
@@ -10,9 +10,9 @@ Describe 'set_default_hibernate_delay_sec function'
       return 0
   }'
 
-  It "should set HIBERNATE_DELAY_SEC=15m"
+  It "should set HIBERNATE_DELAY_SEC=1440m"
     When call set_default_hibernate_delay_sec
-    The variable HIBERNATE_DELAY_SEC should equal '15m'
+    The variable HIBERNATE_DELAY_SEC should equal '1440m'
   End
 
 End


### PR DESCRIPTION
The default HibernateDelaySec is now 1440m.

This is 24h. We assume the following scenario. 

> A user uses a PC every day at the same time. For example, he turned on the PC at 9:00 AM and closed the lid at 7:00 PM. With the 24h HibernateDelaySec, PC doesn't hibernate at 9:00 AM of the next day. So, the resume is quick. 
> Assume the user takes a rest on the weekend. Then, the PC hibernates at 7:00 PM on the weekend. Therefore, the user can conserve battery power on the first day of the weekend. 