### PR TITLE
Add followings to lib/functions.sh :

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -203,11 +203,12 @@ validate_swap_file_size() {
 # Save original swap size
 save_original_swap_size() {
     # This directory is shared with inform_swap_location_to_kernel() function.
-    BACKUPDIR=backup
+    BACKUPDIR=$(get_backup_dir_name)
+    SWAPSIZEFILE=$(get_original_swap_size_file_name)
 
     mkdir -p "$BACKUPDIR"
     ORIGINAL_SWAP_SIZE=$(free --mega | awk '/Swap:/{print $2}')
-    write_stream "$ORIGINAL_SWAP_SIZE" "$BACKUPDIR/original_swap_size" 
+    write_stream "$ORIGINAL_SWAP_SIZE" "$BACKUPDIR/$SWAPSIZEFILE" 
 
     return 0
 }
@@ -275,6 +276,9 @@ resize_swap_file() {
 inform_swap_location_to_kernel() {
     echo "----------- Editing GRUB configuration -----------"
 
+    # Get the file name to store original grub.
+    GRUBFILE=$(get_original_grub_file_name)
+
 
     # Get the UUID of the root filesystem (where the swap file stays).
     UUID=$(findmnt / -o UUID --noheadings)
@@ -315,7 +319,7 @@ inform_swap_location_to_kernel() {
         return 1
     else
         # Save the original file.
-        write_file "$SAVED_GRUB" "$BACKUPDIR/original_grub_config"
+        write_file "$SAVED_GRUB" "$BACKUPDIR/$GRUBFILE"
     fi
 
     echo "----------- GRUB configuration updated -----------"
@@ -381,6 +385,35 @@ EOF
     fi
     echo "----------- Configuration complete -----------"
 
+    return 0
+}
+
+#----------------------------------------------------------------------
+#
+# Obtain the file name of the saved original grub file.
+#
+get_original_grub_file_name() {
+    printf "%s\n" "original_grub_config"
+
+    return 0
+}
+
+#----------------------------------------------------------------------
+#
+# Obtain the file name of the saved original swap size.
+#
+get_original_swap_size_file_name() {
+    printf "%s\n" "original_swap_size" 
+
+    return 0
+}
+
+#----------------------------------------------------------------------
+#
+# Obtain the backup directory name.
+#
+get_backup_dir_name() {
+    printf "%s\n" "backup"
     return 0
 }
 

--- a/revert.sh
+++ b/revert.sh
@@ -1,20 +1,25 @@
 #!/bin/sh
 
+
+. ./lib/functions.sh
+
 #######################################################################
 #
 # This script is used to revert the changes made by fuyujitaku.sh.
 #
 #######################################################################
-BACKUPDIR=backup
+BACKUPDIR=$(get_backup_dir_name)
+SIZEFILE=$(get_original_swap_size_file_name)
+GRUBFILE=$(get_original_grub_file_name)
 
 # Check if the original swap size file exists
-if [ ! -f "$BACKUPDIR"/swap_size ]; then
+if [ ! -f "$BACKUPDIR"/"$SIZEFILE" ]; then
     echo "Original swap size file not found."
     echo "Aborted."
     exit 1
 fi
 # Read the original swap size
-ORIGINAL_SWAP_SIZE=$(cat "$BACKUPDIR"/swap_size)
+ORIGINAL_SWAP_SIZE=$(cat "$BACKUPDIR"/"$SIZEFILE")
 echo "Original swap size: $ORIGINAL_SWAP_SIZE MB"
 
 #-----------------------------------------------------------------------    
@@ -60,7 +65,7 @@ if [ $? -ne 0 ]; then
 fi
 #-----------------------------------------------------------------------
 # Retrieve the grub file.
-sudo cp "$BACKUPDIR"/grub /etc/default/grub
+sudo cp "$BACKUPDIR"/"$GRUBFILE" /etc/default/grub
 if [ $? -ne 0 ]; then
     echo "!!!!! Failed to copy grub file."
     echo "!!!!! Aborted."

--- a/spec/get_backup_dir_name_spec.sh
+++ b/spec/get_backup_dir_name_spec.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+Include 'lib/functions.sh'
+
+Describe 'get_backup_dir_name function'
+
+  It 'should the output the name of the backup directory to stdout.'
+    When call get_backup_dir_name
+    The output should equal "backup"
+  End
+End

--- a/spec/get_original_grub_file_name_spec.sh
+++ b/spec/get_original_grub_file_name_spec.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+Include 'lib/functions.sh'
+
+Describe 'get_original_grub_file_name function'
+
+  It 'should the output the name of the file which contains the original grub to stdout.'
+    When call get_original_grub_file_name
+    The output should equal "original_grub_config"
+  End
+End

--- a/spec/get_original_swap_size_file_name_spec.sh
+++ b/spec/get_original_swap_size_file_name_spec.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+Include 'lib/functions.sh'
+
+Describe 'get_original_swap_size_file_name function'
+
+  It 'should the output the name of the file which contains the original swap file size to stdout.'
+    When call get_original_swap_size_file_name
+    The output should equal "original_swap_size"
+  End
+End

--- a/spec/save_original_swap_size_spec.sh
+++ b/spec/save_original_swap_size_spec.sh
@@ -2,7 +2,7 @@
 
 Include 'lib/functions.sh'
 
-Describe 'print_parametsave_original_swap_sizeers function'
+Describe 'save_original_swap_size function'
   # Mock of write_stream() function 
   write_stream() {
     STREAM="$1"        


### PR DESCRIPTION
Following functions are added to the lib/functions.sh. 

- get_backup_dir_name
- get_original_grub_file_name
- get_original_swap_size_file_name

These functions are shared between the fuyujitaku.sh and  the revert.sh.

So, it fixes the problem reported by Issue #12 .
